### PR TITLE
Parse rating value correctly

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -92,9 +92,7 @@ var searchExtractTab = function ($, tr) {
   var $td3 = $(tds[2]);
   var $rating = $td3.find('.rating');
   if ($rating) {
-    if ($rating.find('span').length == 5) {
-      tab['rating'] = $rating.find('span').length;
-    }
+    tab['rating'] = parseFloat($rating.attr('title'))
   }
   // Number of rates.
   var $ratdig = $td3.find('.ratdig');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -100,11 +100,6 @@ var searchExtractTab = function ($, tr) {
     var numberRates = parseInt($ratdig.text());
       tab['numberRates'] = numberRates;
   }
-  // Rating and numberRates should be present.
-  if (tab.hasOwnProperty('rating') || tab.hasOwnProperty('numberRates')) {
-    delete tab['rating'];
-    delete tab['numberRates'];
-  }
   // Type.
   var $td4 = $(tds[3]);
   var type = removeShit($td4.text().trim());


### PR DESCRIPTION
Ratings were always being parsed as 5, this PR fixes that and parses the `title` attributes of the `.rating` span, which contains the numerical rating.